### PR TITLE
Add hero section to about page layout

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -4,6 +4,14 @@ layout: default
 
 <!-- about.html -->
       <div class="post">
+        <section class="about-hero">
+          <div class="hero-content">
+            <h1 class="hero-title">{{ page.hero_title | default: page.title }}</h1>
+            {% if page.hero_subtitle %}
+            <p class="hero-subtitle">{{ page.hero_subtitle }}</p>
+            {% endif %}
+          </div>
+        </section>
         <header class="post-header">
           <h1 class="post-title">
            {% if site.title == "blank" -%}<span class="font-weight-bold">{{ site.first_name }}</span> {{ site.middle_name }} {{ site.last_name }}{%- else -%}{{ site.title }}{%- endif %}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -33,6 +33,24 @@ body.sticky-bottom-footer {
   }
 }
 
+// Hero section for about page
+.about-hero {
+  background: $gradient-primary;
+  color: $white-color;
+  padding: 4rem 1rem;
+  text-align: center;
+
+  .hero-title {
+    margin: 0;
+    font-size: 2.5rem;
+  }
+
+  .hero-subtitle {
+    margin-top: 0.5rem;
+    font-size: 1.25rem;
+  }
+}
+
 // TODO: redefine content layout.
 
 


### PR DESCRIPTION
## Summary
- Add configurable hero block to the about page layout
- Style hero section with gradient background and centered text

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a35296efc483269a5e21a6d443879c