### PR TITLE
Remove hero panel and streamline scripts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -284,8 +284,8 @@ enable_google_analytics: false # enables google analytics
 enable_panelbear_analytics: false # enables panelbear analytics
 enable_google_verification: false # enables google site verification
 enable_bing_verification: false # enables bing site verification
-enable_masonry: true # enables automatic project cards arangement
-enable_math: true # enables math typesetting (uses MathJax)
+enable_masonry: false # enables automatic project cards arangement
+enable_math: false # enables math typesetting (uses MathJax)
 enable_tooltips:
     false # enables automatic tooltip links generated
     # for each section titles on pages and posts
@@ -296,7 +296,7 @@ enable_navbar_social:
 enable_project_categories:
     true # enables categorization of projects into
     # multiple categories
-enable_medium_zoom: true # enables image zoom feature (as on medium.com)
+enable_medium_zoom: false # enables image zoom feature (as on medium.com)
 
 # -----------------------------------------------------------------------------
 # Library versions

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -4,14 +4,6 @@ layout: default
 
 <!-- about.html -->
       <div class="post">
-        <section class="about-hero">
-          <div class="hero-content">
-            <h1 class="hero-title">{{ page.hero_title | default: page.title }}</h1>
-            {% if page.hero_subtitle %}
-            <p class="hero-subtitle">{{ page.hero_subtitle }}</p>
-            {% endif %}
-          </div>
-        </section>
         <header class="post-header">
           <h1 class="post-title">
            {% if site.title == "blank" -%}<span class="font-weight-bold">{{ site.first_name }}</span> {{ site.middle_name }} {{ site.last_name }}{%- else -%}{{ site.title }}{%- endif %}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -33,24 +33,6 @@ body.sticky-bottom-footer {
   }
 }
 
-// Hero section for about page
-.about-hero {
-  background: $gradient-primary;
-  color: $white-color;
-  padding: 4rem 1rem;
-  text-align: center;
-
-  .hero-title {
-    margin: 0;
-    font-size: 2.5rem;
-  }
-
-  .hero-subtitle {
-    margin-top: 0.5rem;
-    font-size: 1.25rem;
-  }
-}
-
 // TODO: redefine content layout.
 
 


### PR DESCRIPTION
## Summary
- strip hero panel from about page layout and stylesheet
- disable MathJax, Masonry, and medium zoom to reduce external JS and improve load times

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a35b9103608326892a4097c8265cfe