### PR TITLE
Fix navbar social icons disappearing on hover

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -321,27 +321,21 @@ blockquote {
     padding-bottom: 0;
     padding-top: 0;
     font-size: 1.5rem;
-    
+
     a {
       margin: 0 0.5rem !important;
       position: relative !important;
-      
+      color: var(--global-text-color) !important;
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
+
       // Override any general link styles
       &::after {
         display: none !important;
       }
-      
-      i::before {
-        color: var(--global-text-color) !important;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
-      }
-      
+
       &:hover {
+        color: var(--global-theme-color) !important;
         transform: translateY(-3px) !important;
-        
-        i::before {
-          color: var(--global-theme-color) !important;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure navbar social links retain visible color on hover

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a35f2135c48326b6a5b21804da6a3d