### PR TITLE
Fix mobile image loading

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -250,10 +250,10 @@ filtered_bibtex_keywords: [
 # Responsive WebP Images
 # -----------------------------------------------------------------------------
 
-enable_responsive_images: true # enables responsive images for your site (recomended, see https://github.com/alshedivat/al-folio/issues/537)
+enable_responsive_images: false # disable responsive images to ensure photos load on all devices
 
 imagemagick:
-    enabled: true # make it 'false' if not using responsive images
+    enabled: false # disable imagemagick since responsive images are not generated on GitHub Pages
     widths:
         - 480
         - 800


### PR DESCRIPTION
## Summary
- disable responsive images in config so photos load on mobile
- disable imagemagick plugin since GitHub Pages doesn't build derived images

## Testing
- `bundle exec jekyll build` *(fails: jekyll: command not found)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a769f5549483268011dd1af83d60c2