### PR TITLE
feat: randomize color palettes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,9 @@
     {% endif %}
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
-    
+
+    <script src="{{ '/assets/js/palette.js' | relative_url }}"></script>
+
     <!-- Dark Mode -->
     {% if site.enable_darkmode %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jwarby/jekyll-pygments-themes@master/{{ site.highlight_theme_dark | append: '.css' }}" media="none" id="highlight_theme_dark" />

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -111,3 +111,60 @@ html[data-theme='dark'] {
     display : none;
   }
 }
+
+// Additional Color Palettes
+
+// Purple Palette
+html.palette-purple {
+  --global-theme-color: #6D28D9;
+  --global-theme-color-dark: #4C1D95;
+  --global-theme-color-light: #A78BFA;
+  --global-accent-color: #F472B6;
+  --global-secondary-color: #10B981;
+  --global-hover-color: #4C1D95;
+}
+html.palette-purple[data-theme='dark'] {
+  --global-theme-color: #A78BFA;
+  --global-theme-color-dark: #6D28D9;
+  --global-theme-color-light: #C4B5FD;
+  --global-accent-color: #F472B6;
+  --global-secondary-color: #10B981;
+  --global-hover-color: #A78BFA;
+}
+
+// Green Palette
+html.palette-green {
+  --global-theme-color: #065F46;
+  --global-theme-color-dark: #064E3B;
+  --global-theme-color-light: #34D399;
+  --global-accent-color: #FBBF24;
+  --global-secondary-color: #3B82F6;
+  --global-hover-color: #064E3B;
+}
+html.palette-green[data-theme='dark'] {
+  --global-theme-color: #34D399;
+  --global-theme-color-dark: #065F46;
+  --global-theme-color-light: #6EE7B7;
+  --global-accent-color: #FBBF24;
+  --global-secondary-color: #3B82F6;
+  --global-hover-color: #34D399;
+}
+
+// Red Palette
+html.palette-red {
+  --global-theme-color: #991B1B;
+  --global-theme-color-dark: #7F1D1D;
+  --global-theme-color-light: #F87171;
+  --global-accent-color: #14B8A6;
+  --global-secondary-color: #FBBF24;
+  --global-hover-color: #7F1D1D;
+}
+html.palette-red[data-theme='dark'] {
+  --global-theme-color: #F87171;
+  --global-theme-color-dark: #991B1B;
+  --global-theme-color-light: #FCA5A5;
+  --global-accent-color: #14B8A6;
+  --global-secondary-color: #FBBF24;
+  --global-hover-color: #F87171;
+}
+

--- a/assets/js/palette.js
+++ b/assets/js/palette.js
@@ -1,0 +1,8 @@
+(function() {
+  const palettes = [null, 'palette-purple', 'palette-green', 'palette-red'];
+  const choice = palettes[Math.floor(Math.random() * palettes.length)];
+  if (choice) {
+    document.documentElement.classList.add(choice);
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add four color palettes and apply one at random for each visit
- expose palette script in head for early execution

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a76dd587608326b140eabdb01f48cb